### PR TITLE
mintGene => verifyProof

### DIFF
--- a/contracts/VPBM.sol
+++ b/contracts/VPBM.sol
@@ -27,7 +27,7 @@ contract VPBM is Ownable {
         rootHash = _rootHash;
     }
 
-    function mintGene(bytes32 _leaf, bytes32[] calldata _proof) public virtual returns (bool) {
+    function verifyProof(bytes32 _leaf, bytes32[] calldata _proof) public virtual returns (bool) {
         require(!geneMinted[_leaf], "This gene has already been minted");
         require(MerkleProof.verify(_proof, rootHash, _leaf), "Invalid Proof");
         geneMinted[_leaf] = true;


### PR DESCRIPTION
Renamed mintGene method to verifyProof. This contract does not actually mint the gene so it was confusing. The minting contract will inherit this method and call verifyProof instead, which makes more sense.