### PR TITLE
remove symbol mapping

### DIFF
--- a/contracts/VPBM.sol
+++ b/contracts/VPBM.sol
@@ -16,10 +16,6 @@ contract VPBM is Ownable {
     /// IPFS and the corresponding root hash below will be replaced.
     bytes32 public rootHash;
 
-    /// @notice Mapping to track when a gene has been minted
-    /// gene symbol => bool
-    mapping(bytes32 => bool) public geneMinted;
-
     /// @param _rootHash current Merkle Tree root hash
     constructor(bytes32 _rootHash) {
         rootHash = _rootHash;
@@ -32,7 +28,6 @@ contract VPBM is Ownable {
     function verifyProof(bytes32 _leaf, bytes32[] calldata _proof) public virtual returns (bool) {
         require(!geneMinted[_leaf], "Gene has already been minted");
         require(MerkleProof.verify(_proof, rootHash, _leaf), "Invalid Proof");
-        geneMinted[_leaf] = true;
         return true;
     }
 


### PR DESCRIPTION
Modify VPBM to remove the symbol mapping. This logic will be handled in the minting contract instead.